### PR TITLE
Added 'stderr' to promise result

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ class ChildProcess {
             child = this.child_process
                 .fork(modulePath, args, options)
                 .on('close', (code, signal) => {
-                    resolve({code: code, signal: signal, stdout: stdout});
+                    resolve({code: code, signal: signal, stdout: stdout, stderr: stderr});
                 })
                 .on('error', (error) => {
                     error.stderr = stderr;

--- a/index.js
+++ b/index.js
@@ -142,7 +142,7 @@ class ChildProcess {
             child = this.child_process
                 .spawn(command, args, options)
                 .on('close', (code, signal) => {
-                    resolve({code: code, signal: signal, stdout: stdout});
+                    resolve({code: code, signal: signal, stdout: stdout, stderr: stderr});
                 })
                 .on('error', (error) => {
                     error.stderr = stderr;


### PR DESCRIPTION
This allows code like this:

```js
let result = await cp.spawn('rm', ['non-existing-file']);
console.log(result.stderr);
```

**Note**: there are possibly other places in the code where similar change should be made, I was only interested in `spawn()` and am not too familiar with the others so I'll leave it to someone else :)