### PR TITLE
spawn() support for binary buffering

### DIFF
--- a/test.js
+++ b/test.js
@@ -72,6 +72,16 @@ describe('child-process-es6-promise', () => {
         it('should not throw when {stdio: inherit}', () => {
             return cp.spawn('echo', ['test'], {stdio: 'inherit', shell: true})
         });
+        it('should return a buffer with { binary: true }', () => {
+            return cp.spawn('printf', ['"\\x7f\\x50"'], {binary: true, shell: true})
+                .then((result)=> {
+                    assert.equal(result.code, 0);
+                    assert.equal(result.signal, null);
+                    assert(result.stdout instanceof Buffer);
+                    assert(result.stdout[0] === 0x7f);
+                    assert(result.stdout[1] === 0x50);
+                });
+        });
     });
 
     describe('const {spawn} = cp', () => {


### PR DESCRIPTION
This adds support for binary buffering in `spawn()`. It concatenates the data in binary form as it comes in, and then decodes it before returning it. When binary data is desired `{ binary: true }` it returns the raw buffer.